### PR TITLE
updating filepath and users to match machine charm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,17 @@
 # See LICENSE file for licensing details.
 FROM ubuntu:20.04
 
-RUN useradd -M pgbouncer && \
-    apt-get -y update && \
+RUN apt-get -y update && \
     apt-get -y install pgbouncer=1.12.0-3 --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
-    chown -R postgres /etc/pgbouncer
+    mkdir /var/lib/postgresql/pgbouncer && \
+    chown postgres /var/lib/postgresql/pgbouncer
 
-USER pgbouncer
+# Installed with pgbouncer
+USER postgres
 
-WORKDIR /etc/pgbouncer
+WORKDIR /var/lib/postgresql/pgbouncer
 
-COPY --chown=pgbouncer ./docker-entrypoint.sh /docker-entrypoint.sh
+COPY --chown=postgres ./docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-PGB_DIR="/etc/pgbouncer"
+PGB_DIR="/var/lib/postgresql/pgbouncer"
 INI="${PGB_DIR}/pgbouncer.ini"
 USERLIST="${PGB_DIR}/userlist.txt"
 


### PR DESCRIPTION
## Proposal
This PR implements some minor changes to the pgbouncer container so the pgbouncer-k8s-operator charm has the same user and filesystem as the machine charm. 

## Release Notes
- removed pgbouncer user. The charms now use the `postgres` user, which is generated when pgbouncer is installed via apt. However, this user can't access /etc/pgbouncer, so we move the pgbouncer installation to /var/lib/postgresql/pgbouncer.

## Testing
This has been used when building/testing the pgbouncer-k8s-operator charm. 