### PR TITLE
updated base container image to 22.04, and pgbouncer to 1.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get -y update && \
-    apt-get -y install pgbouncer=1.12.0-3 --no-install-recommends && \
+    apt-get -y install pgbouncer=1.16.1-1ubuntu1 --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /var/lib/postgresql/pgbouncer && \
     chown postgres /var/lib/postgresql/pgbouncer


### PR DESCRIPTION
## Proposal
Updates the base container image to jammy, allowing us to install pgbouncer v1.16.1, which has a lot more functionality.

## Context
- This is currently untested on the pgbouncer charm, which currently uses `pgbouncer:latest`. I'm going to open a PR to switch that to the v1.12 container, then update it to use the 22.04 container manually, with tests.
  - Therefore, when releasing this container, please don't release it to `latest` right away. 

## Release Notes
- update base container image to use ubuntu jammy (22.04) and pgbouncer to 1.16.1.